### PR TITLE
Update pnpm to v11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rsswk",
 	"version": "0.0.0",
 	"private": true,
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",


### PR DESCRIPTION
## Summary

- update the package manager source of truth to `pnpm@11.13.0`
- keep the workflows reading the version from `package.json`
- leave `pnpm-lock.yaml` unchanged because pnpm 11.13.0 found no resolution changes

## Root cause

The pnpm 11.12.0 update failed in `pnpm/action-setup@v6.0.9` before repository checks ran. The self-installer attempted to switch from pnpm 11.7.0 to 11.12.0 and exited with `Cannot use 'in' operator to search for 'integrity' in undefined`.

pnpm 11.13.0 includes the corrected published package structure for this self-update path.

## Validation

- `CI=true pnpm install --lockfile-only`
- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm run lint`
- `CI=true pnpm run fmt:check`
- `CI=true pnpm exec tsc --noEmit`
- `CI=true pnpm exec tsc -p test/tsconfig.json --noEmit`
- `CI=true pnpm run test`
- `CI=true pnpm run cf-typegen`
- `git diff --exit-code -- worker-configuration.d.ts`
- `pinact run --check`
- `zizmor --format plain .`

No build script is configured in this repository.
