### PR TITLE
Run independent CI checks in parallel

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -25,12 +25,13 @@ jobs:
         with:
           aqua_version: v2.61.0
 
-      - name: Check action pinning
-        run: pinact run --check
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - parallel:
+          - name: Check action pinning
+            run: pinact run --check
+            env:
+              GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Audit workflows
-        run: zizmor --format github .
-        env:
-          GH_TOKEN: ${{ github.token }}
+          - name: Audit workflows
+            run: zizmor --format github .
+            env:
+              GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,25 +16,12 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: true
-      - run: pnpm run lint
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          run_install: true
-      - run: pnpm run fmt:check
-  cf-typegen:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          run_install: true
+      - parallel:
+          - name: Lint
+            run: pnpm run lint
+          - name: Check format
+            run: pnpm run fmt:check
+      # Run type generation after lint because type-aware lint reads worker-configuration.d.ts.
+      # The diff check must also wait for type generation to finish.
       - run: pnpm run cf-typegen
       - run: git diff --exit-code -- worker-configuration.d.ts


### PR DESCRIPTION
## Summary

- consolidate CI jobs that used the same pnpm setup
- run lint and format checks in a `parallel:` group
- keep Cloudflare type generation sequential because type-aware lint reads `worker-configuration.d.ts`
- keep the generated-file diff check after type generation because it depends on the completed output
- run pinact and zizmor in parallel

## Verification

- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm run cf-typegen`
- `git diff --exit-code -- worker-configuration.d.ts`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`